### PR TITLE
Fix(Core/Quest) Fresh out of the Grave ID 24959

### DIFF
--- a/sql/updates/world/2022_06_28_00.sql
+++ b/sql/updates/world/2022_06_28_00.sql
@@ -1,6 +1,2 @@
 
-UPDATE `playercreateinfo` SET `position_x`=1704.12, `position_y`=1704.64, `position_z`=133.95, `orientation`=4.70 WHERE `race`=5 and `map`=0 and `zone`=5692;
-
-UPDATE `creature` SET `position_x`=1704.32, `position_y`=1702.44, `position_z`=137.26, `orientation`=1.59 WHERE `id`=49044;
-
 UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_agatha' WHERE `entry`=49044;

--- a/sql/updates/world/2022_06_28_00.sql
+++ b/sql/updates/world/2022_06_28_00.sql
@@ -1,0 +1,6 @@
+
+UPDATE `playercreateinfo` SET `position_x`=1704.12, `position_y`=1704.64, `position_z`=133.95, `orientation`=4.70 WHERE `race`=5 and `map`=0 and `zone`=5692;
+
+UPDATE `creature` SET `position_x`=1704.32, `position_y`=1702.44, `position_z`=137.26, `orientation`=1.59 WHERE `id`=49044;
+
+UPDATE `creature_template` SET `AIName`='', `ScriptName`='npc_agatha' WHERE `entry`=49044;

--- a/src/server/newscripts/EasternKingdoms/tirisfal_glades.cpp
+++ b/src/server/newscripts/EasternKingdoms/tirisfal_glades.cpp
@@ -157,32 +157,47 @@ class spell_summon_darnel_q26800 : public AuraScript
     }
 };
 
-class player_undead_start_zone : public PlayerScript
+enum loginUndead
 {
-    public:
-        player_undead_start_zone() : PlayerScript("player_undead_start_zone") {} 
-        
-       void OnLogin(Player* player, bool firstLogin) override
+    SPELL_RIGOR_MORTIS = 73523,
+    QUEST_FRESH_OUT_OF_THE_GRAVE = 24959,
+    SPELL_VALKYR_RESURRECTION = 73524
+};
+
+class first_login_undead : public PlayerScript
+{
+public:
+    first_login_undead() : PlayerScript("first_login_undead") { }
+
+    void OnLogin(Player* player)
     {
-           if (!player || player->isGameMaster())
-               return;
+        if (player->getRace() == RACE_UNDEAD_PLAYER && player->GetQuestStatus(QUEST_FRESH_OUT_OF_THE_GRAVE) == QUEST_STATE_NONE)
+        {
+            player->AddAura(SPELL_RIGOR_MORTIS, player);
+        }
+    }
+};
 
-           if (player->getRace() == RACE_UNDEAD_PLAYER)
-           {
-               player->CastSpell(player, 73523); //spell fake death
-           }
+class npc_agatha : public CreatureScript
+{
+public:
+    npc_agatha() : CreatureScript("npc_agatha") { }
 
-           if (player->hasQuest(24959)) 
-           {
-               player->CastSpell(player, 73524); //spell revivir
-               player->RemoveAurasDueToSpell(73523); //spell fake death
-           }
+    bool OnQuestAccept(Player* player, Creature* /*creature*/, Quest const* quest) override
+    {
+        if (quest->GetQuestId() == QUEST_FRESH_OUT_OF_THE_GRAVE)
+        {
+            player->CastSpell(player, SPELL_VALKYR_RESURRECTION);
+            player->RemoveAura(SPELL_RIGOR_MORTIS);
+        }
+        return true;
     }
 };
 
 void AddSC_tirisfal_glades()
 {
-    new player_undead_start_zone();
+    new first_login_undead();
+    new npc_agatha();
     RegisterCreatureAI(npc_darnel_q26800);
     RegisterCreatureAI(npc_scarlet_corpse_q26800);
     RegisterCreatureAI(npc_deathguard_saltain);


### PR DESCRIPTION
- [x] The script has been modified, because it did not fulfill the function of removing the player's aura, when completing the quest. It also applies a revive spell that was in the original script.
- [x] The script is assigned in the emulator, and it is checked that it does not have an `AIName` script. For some reason, it had a script assigned in SQL, which does not exist.

![WoWScrnShot_062822_102526](https://user-images.githubusercontent.com/2810187/176190283-189962d7-5c64-499a-ae84-7c70e5d0cc4d.jpg)

![WoWScrnShot_062822_102530](https://user-images.githubusercontent.com/2810187/176190288-5915679c-82cd-4d59-81f9-21a64d11c4ae.jpg)

![WoWScrnShot_062822_102614](https://user-images.githubusercontent.com/2810187/176190291-34d81d04-0f20-4575-be8d-53d5c41a6777.jpg)
